### PR TITLE
Fixing longitude field misspelling

### DIFF
--- a/src/main/java/com/plaid/client/response/Transaction.java
+++ b/src/main/java/com/plaid/client/response/Transaction.java
@@ -205,7 +205,7 @@ public class Transaction {
         private Double longitude;
         private Double latitude;
 
-        @JsonProperty("lng")
+        @JsonProperty("lon")
         public Double getLongitude() {
             return longitude;
         }


### PR DESCRIPTION
There's an incorrect mapping in Transaction.Coordinates, where longitude is expected to be at "lng" but the API actually returns it at "lon" (at least in the Tartan API and other API documentation).